### PR TITLE
Use pre-Explain SQL for `WithoutQueryVariables`

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -116,16 +116,13 @@ func (p *otelPlugin) after() gormHookFunc {
 		}
 
 		vars := tx.Statement.Vars
+
+		var query string
 		if p.excludeQueryVars {
-			// Replace query variables with '?' to mask them
-			vars = make([]interface{}, len(tx.Statement.Vars))
-
-			for i := 0; i < len(vars); i++ {
-				vars[i] = "?"
-			}
+			query = tx.Statement.SQL.String()
+		} else {
+			query = tx.Dialector.Explain(tx.Statement.SQL.String(), vars...)
 		}
-
-		query := tx.Dialector.Explain(tx.Statement.SQL.String(), vars...)
 
 		attrs = append(attrs, semconv.DBStatementKey.String(p.formatQuery(query)))
 		if tx.Statement.Table != "" {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
The current implementation of `WithoutQueryVariables` substitutes `?` for any query variables and calls `tx.Dialector.Explain`, which can result in a lot of string allocations. This implementation avoids the substitution and uses whatever the default representation of the query parameters is for the SQL dialect.

Fixes #14 

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
We had performance issues with the previous implementation of tracing with the `WithoutQueryVariables` option.
<!-- Your use case -->
