### PR TITLE
feat: send operation name

### DIFF
--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -44,6 +44,10 @@ func TestOtel(t *testing.T) {
 				stmt, ok := m[semconv.DBStatementKey]
 				require.True(t, ok)
 				require.Equal(t, "SELECT 42", stmt.AsString())
+
+				operation, ok := m[semconv.DBOperationKey]
+				require.True(t, ok)
+				require.Equal(t, "select", operation.AsString())
 			},
 		},
 		{
@@ -69,6 +73,10 @@ func TestOtel(t *testing.T) {
 				stmt, ok := m[semconv.DBStatementKey]
 				require.True(t, ok)
 				require.Equal(t, "SELECT foo_bar", stmt.AsString())
+
+				operation, ok := m[semconv.DBOperationKey]
+				require.True(t, ok)
+				require.Equal(t, "select", operation.AsString())
 			},
 		},
 		{
@@ -98,6 +106,10 @@ func TestOtel(t *testing.T) {
 				stmt, ok := m[semconv.DBStatementKey]
 				require.True(t, ok)
 				require.Equal(t, "SELECT id FROM `foo` WHERE id = ?", stmt.AsString())
+
+				operation, ok := m[semconv.DBOperationKey]
+				require.True(t, ok)
+				require.Equal(t, "select", operation.AsString())
 			},
 		},
 	}


### PR DESCRIPTION
- [ ] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

adds operation name when send otel trace, actually in new relic not show this name

### User Case Description

send db operation name for otel trace