### PR TITLE
allow additional metric configuration in ReportDBStatsMetrics

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -33,7 +33,7 @@ func newConfig() *config {
 }
 
 // ReportDBStatsMetrics reports DBStats metrics using OpenTelemetry Metrics API.
-func ReportDBStatsMetrics(db *sql.DB) {
+func ReportDBStatsMetrics(db *sql.DB, opts ...metric.ObserveOption) {
 	cfg := newConfig()
 
 	if cfg.meter == nil {
@@ -41,7 +41,7 @@ func ReportDBStatsMetrics(db *sql.DB) {
 	}
 
 	meter := cfg.meter
-	opts := cfg.opts
+	opts = append(cfg.opts, opts...)
 
 	maxOpenConns, _ := meter.Int64ObservableGauge(
 		"go.sql.connections_max_open",


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Allows providing additional configuration when using `ReportDBStatsMetrics` directly.

### User Case Description

I'm calling it directly with an additional database name attribute:
```
metrics.ReportDBStatsMetrics(sqlDB, metric.WithAttributes(attribute.String("db", ...)))
```