### PR TITLE
feat: add option to exclude server address attribute

### DIFF
--- a/tracing/option.go
+++ b/tracing/option.go
@@ -56,3 +56,10 @@ func WithRecordStackTrace() Option {
 		p.recordStackTraceInSpan = true
 	}
 }
+
+// WithoutServerAddress excludes db.server_address attribute.
+func WithoutServerAddress() Option {
+	return func(p *otelPlugin) {
+		p.excludeServerAddress = true
+	}
+}

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -125,7 +125,6 @@ func TestOtel(t *testing.T) {
 				require.NoError(t, err)
 			},
 			require: func(t *testing.T, spans []sdktrace.ReadOnlySpan) {
-
 				m := attrMap(spans[0].Attributes())
 				require.Equal(t, "test.dsn", m[semconv.ServerAddressKey].AsString())
 			},
@@ -143,7 +142,6 @@ func TestOtel(t *testing.T) {
 			},
 			opts: []Option{WithoutServerAddress()},
 			require: func(t *testing.T, spans []sdktrace.ReadOnlySpan) {
-
 				m := attrMap(spans[0].Attributes())
 				require.Equal(t, "", m[semconv.ServerAddressKey].AsString())
 			},

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
+	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -110,6 +111,41 @@ func TestOtel(t *testing.T) {
 				operation, ok := m[semconv.DBOperationNameKey]
 				require.True(t, ok)
 				require.Equal(t, "select", operation.AsString())
+			},
+		},
+		{
+			do: func(ctx context.Context, db *gorm.DB) {
+				var num int
+				db.Config.Dialector = &postgres.Dialector{
+					Config: &postgres.Config{
+						DSN: "test.dsn",
+					},
+				}
+				err := db.WithContext(ctx).Raw("SELECT 42").Scan(&num).Error
+				require.NoError(t, err)
+			},
+			require: func(t *testing.T, spans []sdktrace.ReadOnlySpan) {
+
+				m := attrMap(spans[0].Attributes())
+				require.Equal(t, "test.dsn", m[semconv.ServerAddressKey].AsString())
+			},
+		},
+		{
+			do: func(ctx context.Context, db *gorm.DB) {
+				var num int
+				db.Config.Dialector = &postgres.Dialector{
+					Config: &postgres.Config{
+						DSN: "test.dsn",
+					},
+				}
+				err := db.WithContext(ctx).Raw("SELECT 42").Scan(&num).Error
+				require.NoError(t, err)
+			},
+			opts: []Option{WithoutServerAddress()},
+			require: func(t *testing.T, spans []sdktrace.ReadOnlySpan) {
+
+				m := attrMap(spans[0].Attributes())
+				require.Equal(t, "", m[semconv.ServerAddressKey].AsString())
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Add option to exclude database DSN address tracer attribute. 

### User Case Description

Use tracing plugin without report the database DSN address. 
I don't want to add the information to the span for two reasons:
1) I don't want the database address exposed in the APM.
2) when the attribute is added as server.address, DD (Datadog) doesn't recognize it as a DB span. In previous versions, before the address implementation, it appeared in the tab normally.

![image](https://github.com/user-attachments/assets/9dd55866-9858-4f18-a531-9a67161b2d7f)

