### PR TITLE
fix: remove sensitive info of dsn

### DIFF
--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -210,3 +210,94 @@ func attrMap(attrs []attribute.KeyValue) map[attribute.Key]attribute.Value {
 	}
 	return m
 }
+
+// TestExtractServerAddress tests the extractServerAddress function with various DSN formats
+func TestExtractServerAddress(t *testing.T) {
+	tests := []struct {
+		name     string
+		dsn      string
+		expected string
+	}{
+		// Common DSN formats
+		{
+			name:     "ClickHouse URL with credentials",
+			dsn:      "clickhouse://user:password@127.0.0.1:9000/database",
+			expected: "127.0.0.1:9000",
+		},
+		{
+			name:     "ClickHouse URL without credentials",
+			dsn:      "clickhouse://127.0.0.1:9000/database",
+			expected: "127.0.0.1:9000",
+		},
+		{
+			name:     "HTTP URL with credentials",
+			dsn:      "http://user:password@127.0.0.1:8123/database",
+			expected: "127.0.0.1:8123",
+		},
+		{
+			name:     "HTTPS URL with credentials",
+			dsn:      "https://user:password@127.0.0.1:8443/database",
+			expected: "127.0.0.1:8443",
+		},
+		{
+			name:     "TCP URL with query parameters",
+			dsn:      "tcp://127.0.0.1:9000?database=default&username=user&password=secret",
+			expected: "127.0.0.1:9000",
+		},
+
+		// Uncommon DSNs
+		{
+			name:     "Traditional format with credentials",
+			dsn:      "user:password@127.0.0.1:9000/database",
+			expected: "127.0.0.1:9000",
+		},
+		{
+			name:     "Simple host:port format",
+			dsn:      "127.0.0.1:9000",
+			expected: "127.0.0.1:9000",
+		},
+		{
+			name:     "Host with database",
+			dsn:      "127.0.0.1:9000/database",
+			expected: "127.0.0.1:9000",
+		},
+		{
+			name:     "Host with query parameters",
+			dsn:      "127.0.0.1:9000?database=test&timeout=10s",
+			expected: "127.0.0.1:9000",
+		},
+		{
+			name:     "Complex format with all parts",
+			dsn:      "user:password@127.0.0.1:9000/database?param1=value1&param2=value2",
+			expected: "127.0.0.1:9000",
+		},
+
+		{
+			name:     "Empty DSN",
+			dsn:      "",
+			expected: "",
+		},
+		{
+			name:     "IPv6 address with credentials",
+			dsn:      "clickhouse://user:pass@[::1]:9000/db",
+			expected: "[::1]:9000",
+		},
+		{
+			name:     "IPv6 address without credentials",
+			dsn:      "tcp://[2001:db8::1]:9000?database=test",
+			expected: "[2001:db8::1]:9000",
+		},
+		{
+			name:     "Host without port",
+			dsn:      "clickhouse://user:pass@localhost/db",
+			expected: "localhost",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractServerAddress(tt.dsn)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Fix https://github.com/go-gorm/opentelemetry/pull/44. Since `server.address` is a recommended attribute within OTel, the DSN should be sanitized to remove sensitive info, while retaining the `server.address:server.port` for clickhouse and postgresql. 

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
