### PR TITLE
ci(dependabot): setup dependabot to keep the dependencies updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "go"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+    commit-message:
+      prefix: "ci"
+      prefix-development: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This PR sets up dependabot so that this repository gets PRs to update the dependency of this project.

It also updates any workflow's action that has a newer version available.
### User Case Description

Please merge this AFTER #55 is merged (otherwise it's going to cause conflicts once the dependency update PRs start coming through)

This was also mentioned in the #48 issue about automatically updating dependencies.